### PR TITLE
Support Cards and Discounts in events

### DIFF
--- a/src/resources/event.rs
+++ b/src/resources/event.rs
@@ -211,8 +211,10 @@ pub enum EventObject {
     ApplicationFeeRefund(ApplicationFeeRefund),
     Balance(Balance),
     BankAccount(BankAccount),
+    Card(Card),
     Charge(Charge),
     Customer(Customer),
+    Discount(Discount),
     Dispute(Dispute),
     #[serde(rename = "checkout.session")]
     CheckoutSession(CheckoutSession),


### PR DESCRIPTION
Add `Card` and `Discount` enumeration items to `EventObject`. These are
required for e.g. `customer.source.created` and
`customer.discount.created` events.